### PR TITLE
Fixup armhf build

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -79,6 +79,7 @@ parts:
       - build-essential
       - pkg-config
       - python3
+      - libkrb5-dev
     override-build: |
       npm install --verbose --unsafe-perm code-server
       mkdir -p $CRAFT_PART_INSTALL/lib/node_modules \
@@ -99,6 +100,7 @@ parts:
       - git-all # Add submodules etc?
       - openssh-client
       - screen
+      - libatomic1
 
   env-wrapper:
     plugin: dump


### PR DESCRIPTION
Adds libkrb5-dev to build packages as it cannot find the library in that architecture when building
Adds libatomic1 to stage packages as it cannot find the library in that architecture when running